### PR TITLE
metrics[4] save results [GSoC 2023 @ OpenVINO]

### DIFF
--- a/notebooks/500_use_cases/502_perimg_metrics.ipynb
+++ b/notebooks/500_use_cases/502_perimg_metrics.ipynb
@@ -841,7 +841,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# %TODO clean this section and move to folder 502"
+   ]
   },
   {
    "cell_type": "code",

--- a/notebooks/500_use_cases/502_perimg_metrics/502b_compare_models.ipynb
+++ b/notebooks/500_use_cases/502_perimg_metrics/502b_compare_models.ipynb
@@ -473,10 +473,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
     "from matplotlib import pyplot as plt\n",
     "\n",
     "# the funcional interface of the plotting funcions have to be used because the\n",
     "# aulogpimo object is gone\n",
+    "AULogPImO\n",
+    "from anomalib.utils.metrics.perimg.pimo import AULogPImO\n",
     "from anomalib.utils.metrics.perimg.plot import plot_boxplot_logpimo_curves, plot_aulogpimo_boxplot\n",
     "from anomalib.utils.metrics.perimg.common import perimg_boxplot_stats\n",
     "\n",
@@ -485,7 +490,13 @@
     "for axrow, pimoresult, aucs, model in zip(\n",
     "    axes, [pimoresult_padim, pimoresult_patchcore], [aucs_padim, aucs_patchcore], [\"PaDiM\", \"PatchCore\"]\n",
     "):\n",
-    "    _ = plot_aulogpimo_boxplot(aucs, pimoresult.image_classes, axrow[0])\n",
+    "    _ = plot_aulogpimo_boxplot(\n",
+    "        aucs,\n",
+    "        pimoresult.image_classes,\n",
+    "        # optional\n",
+    "        random_model_auc=AULogPImO.random_model_auc_from_bounds(lbound, ubound),\n",
+    "        ax=axrow[0],\n",
+    "    )\n",
     "    _ = axrow[0].set_title(f\"{model} - boxplot\")\n",
     "\n",
     "    bp_stats = perimg_boxplot_stats(aucs, pimoresult.image_classes, only_class=1)\n",
@@ -497,7 +508,7 @@
     "        bp_stats,\n",
     "        lbound,\n",
     "        ubound,\n",
-    "        axrow[1],\n",
+    "        ax=axrow[1],\n",
     "    )\n",
     "    _ = axrow[1].set_title(f\"{model} - curves\")\n",
     "\n",
@@ -508,20 +519,6 @@
     "\n",
     "fig.suptitle(\"AULogPImO: PaDiM vs PatchCore\", fontsize=20)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/500_use_cases/502_perimg_metrics/502b_compare_models.ipynb
+++ b/notebooks/500_use_cases/502_perimg_metrics/502b_compare_models.ipynb
@@ -1,0 +1,549 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compare models\n",
+    "\n",
+    "Two models (PaDiM and PatchCore) will be trained and evaluated with a per-image metric (`AULogPImO`).\n",
+    "\n",
+    "See the notebook `502a_perimg_metrics.ipynb` to firs get familiarized with this metric.\n",
+    "\n",
+    "The model performances are exported and loaded back, then the two models are compared based on each image's scores.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO add link to notebook mentioned above"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Installing Anomalib\n",
+    "\n",
+    "The easiest way to install anomalib is to use pip. You can install it from the command line using the following command:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install anomalib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make a cell print all the outputs instead of just the last one\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "\n",
+    "InteractiveShell.ast_node_interactivity = \"all\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data\n",
+    "\n",
+    "We will use MVTec AD DataModule. \n",
+    "\n",
+    "> See [these notebooks](https://github.com/openvinotoolkit/anomalib/tree/main/notebooks/100_datamodules) for more details on datamodules. \n",
+    "\n",
+    "We assume that `datasets` directory is created in the `anomalib` root directory and `MVTec` dataset is located in `datasets` directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "# NOTE: Provide the path to the dataset root directory.\n",
+    "#   If the datasets is not downloaded, it will be downloaded to this directory.\n",
+    "dataset_root = Path.cwd().parent.parent.parent / \"datasets\" / \"MVTec\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will be working on a segmentation task. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anomalib.data import TaskType\n",
+    "\n",
+    "task = TaskType.SEGMENTATION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And with the `hazelnut` category at resolution of 256x256 pixels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anomalib.data.mvtec import MVTec\n",
+    "\n",
+    "datamodule = MVTec(\n",
+    "    root=dataset_root,\n",
+    "    category=\"hazelnut\",\n",
+    "    image_size=256,\n",
+    "    train_batch_size=32,\n",
+    "    eval_batch_size=32,\n",
+    "    num_workers=8,\n",
+    "    task=task,\n",
+    ")\n",
+    "datamodule.setup()\n",
+    "i, data = next(enumerate(datamodule.test_dataloader()))\n",
+    "print(f'Image Shape: {data[\"image\"].shape} Mask Shape: {data[\"mask\"].shape}')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Models\n",
+    "\n",
+    "We train two models: PaDiM and PatchCore.\n",
+    "\n",
+    "> See [these notebooks](https://github.com/openvinotoolkit/anomalib/tree/main/notebooks/200_models) for more details on models. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PaDiM\n",
+    "\n",
+    "The next cell instantiates and trains PaDiM.\n",
+    "\n",
+    "The `MetricsConfigurationCallback()` will not have metric because they will be created manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytorch_lightning import Trainer\n",
+    "\n",
+    "from anomalib.utils.callbacks import MetricsConfigurationCallback, PostProcessingConfigurationCallback\n",
+    "from anomalib.post_processing import NormalizationMethod, ThresholdMethod\n",
+    "from anomalib.models import Padim\n",
+    "\n",
+    "padim = Padim(\n",
+    "    input_size=(256, 256),\n",
+    "    layers=[\n",
+    "        \"layer1\",\n",
+    "        \"layer2\",\n",
+    "    ],\n",
+    "    backbone=\"resnet18\",\n",
+    "    pre_trained=True,\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    callbacks=[\n",
+    "        PostProcessingConfigurationCallback(\n",
+    "            normalization_method=NormalizationMethod.MIN_MAX,\n",
+    "            threshold_method=ThresholdMethod.ADAPTIVE,\n",
+    "        ),\n",
+    "        MetricsConfigurationCallback(),\n",
+    "    ],\n",
+    "    max_epochs=1,\n",
+    "    num_sanity_val_steps=0,  # does not work for padim\n",
+    "    accelerator=\"auto\",\n",
+    ")\n",
+    "\n",
+    "trainer.fit(datamodule=datamodule, model=padim)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PatchCore\n",
+    "\n",
+    "The next cell instantiates and trains PatchCore.\n",
+    "\n",
+    "The `MetricsConfigurationCallback()` will not have metric because they will be created manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%autoreload 2\n",
+    "\n",
+    "from anomalib.post_processing import ThresholdMethod\n",
+    "\n",
+    "from pytorch_lightning import Trainer\n",
+    "from anomalib.models import Patchcore\n",
+    "\n",
+    "patchcore = Patchcore(\n",
+    "    input_size=(256, 256),\n",
+    "    backbone=\"resnet18\",\n",
+    "    layers=[\n",
+    "        \"layer3\",\n",
+    "    ],\n",
+    "    coreset_sampling_ratio=0.1,\n",
+    "    num_neighbors=9,\n",
+    "    pre_trained=True,\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    callbacks=[\n",
+    "        PostProcessingConfigurationCallback(\n",
+    "            normalization_method=NormalizationMethod.MIN_MAX,\n",
+    "            threshold_method=ThresholdMethod.ADAPTIVE,\n",
+    "        ),\n",
+    "        MetricsConfigurationCallback(),\n",
+    "    ],\n",
+    "    max_epochs=1,\n",
+    "    num_sanity_val_steps=0,  # does not work for patchcore\n",
+    "    accelerator=\"auto\",\n",
+    ")\n",
+    "\n",
+    "trainer.fit(datamodule=datamodule, model=patchcore)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Process test images\n",
+    "\n",
+    "This part is usually happening automatically but here we want to extract the outputs manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "_ = padim.eval()\n",
+    "_ = patchcore.eval()\n",
+    "\n",
+    "anomaly_maps_padim = []\n",
+    "anomaly_maps_patchcore = []\n",
+    "masks = []\n",
+    "\n",
+    "for batchidx, batch in enumerate(datamodule.test_dataloader()):\n",
+    "    anomaly_maps_padim.append(padim.test_step_end(padim.test_step(batch, batchidx))[\"anomaly_maps\"].squeeze(1))\n",
+    "    anomaly_maps_patchcore.append(\n",
+    "        patchcore.test_step_end(patchcore.test_step(batch, batchidx))[\"anomaly_maps\"].squeeze(1)\n",
+    "    )\n",
+    "    masks.append(padim.test_step_end(padim.test_step(batch, batchidx))[\"mask\"].int())\n",
+    "\n",
+    "anomaly_maps_padim = torch.cat(anomaly_maps_padim)\n",
+    "anomaly_maps_patchcore = torch.cat(anomaly_maps_patchcore)\n",
+    "masks = torch.cat(masks)\n",
+    "\n",
+    "print(f\"{anomaly_maps_padim.shape=} {anomaly_maps_patchcore.shape=} {masks.shape=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `AULogPImO`\n",
+    "\n",
+    "> Area Under the Log Per-Image Overlap curve; pronounced \"a-u-log-pee-mo\"\n",
+    "\n",
+    "Reminder of the metric definition.\n",
+    "\n",
+    "The `LogPImO` curves have a shared X-axis and a per-image Y-axis.\n",
+    "\n",
+    "The X-axis (\"shared-FPR\"):\n",
+    "- is a metric of False Positives only in the normal images (here it is the log10 of the mean of in-image FPRs, which equals the set-FPR)\n",
+    "- is shared by all anomalous images/curves\n",
+    "\n",
+    "The Y-axis: \n",
+    "- is, at a given threshold (index by the X-axis), the **overlap** between the binary predicted mask and the ground truth mask, which corresponds to the in-image TPR\n",
+    "- has one value per image, so there is one LogPImO curve per image. \n",
+    "\n",
+    "> - FPR: False Positive Rate\n",
+    "> - TPR: True Positive Rate\n",
+    "\n",
+    "The `AULogPImO` $\\in [0, 1]$ is the area under each of these curves normalized by the maximum possible area (when TPR is constant at 1 for all FPR values):\n",
+    "\n",
+    "$$\n",
+    "    \\frac{\\int_{L}^{U} \\; \\text{TPR}( \\, \\text{FPR} \\, ) \\; d\\text{log(FPR)}}{log(U/L)} \n",
+    "    \\quad ,\n",
+    "    \n",
+    "$$\n",
+    "\n",
+    "where $L \\in (0, 1)$ is the shared-FPR lower bound, and $U \\in (0, 1]$ is the shared-FPR upper bound such that $U > L$.\n",
+    "\n",
+    "> **Score of a random model**\n",
+    "> \n",
+    "> The `AULogPImO` score of a random model (i.e. $\\text{TPR}(\\text{FPR}) = \\text{FPR}$) is \n",
+    ">    \n",
+    "> $$\n",
+    "> \\frac{U - L}{log(U / L)}\n",
+    "> \\quad .\n",
+    "> $$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PaDiM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%autoreload 2\n",
+    "import scipy as sp\n",
+    "from anomalib.utils.metrics.perimg import AULogPImO\n",
+    "\n",
+    "aulogpimo_padim = AULogPImO(lbound=0.001, ubound=0.03)\n",
+    "print(f\"AULogPImO of a random model: {aulogpimo_padim.random_model_auc:.1%}\")\n",
+    "aulogpimo_padim.cpu()\n",
+    "aulogpimo_padim.update(anomaly_maps_padim, masks)\n",
+    "pimoresult_padim, aucs_padim = aulogpimo_padim.compute()\n",
+    "print(sp.stats.describe(aucs_padim[~torch.isnan(aucs_padim)]))  # `~torch.isnan(aucs)` is removing the `nan`s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = aulogpimo_padim.plot()\n",
+    "_ = fig.suptitle(\"AULogPImO of PADIM\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PatchCore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%autoreload 2\n",
+    "import scipy as sp\n",
+    "from anomalib.utils.metrics.perimg import AULogPImO\n",
+    "\n",
+    "aulogpimo_patchcore = AULogPImO(lbound=0.001, ubound=0.03)\n",
+    "print(f\"AULogPImO of a random model: {aulogpimo_patchcore.random_model_auc:.1%}\")\n",
+    "aulogpimo_patchcore.cpu()\n",
+    "aulogpimo_patchcore.update(anomaly_maps_patchcore, masks)\n",
+    "pimoresult_patchcore, aucs_patchcore = aulogpimo_patchcore.compute()\n",
+    "print(sp.stats.describe(aucs_patchcore[~torch.isnan(aucs_patchcore)]))  # `~torch.isnan(aucs)` is removing the `nan`s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = aulogpimo_patchcore.plot()\n",
+    "_ = fig.suptitle(\"AULogPImO of PatchCore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save\n",
+    "\n",
+    "Save the AUCs from both models in the disk.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "CACHE = Path() / \".cache\" / \"502b\"\n",
+    "CACHE.mkdir(exist_ok=True, parents=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aulogpimo_padim.save(CACHE / \"aulogpimo_padim.json\")\n",
+    "aulogpimo_patchcore.save(CACHE / \"aulogpimo_patchcore.json\")\n",
+    "\n",
+    "%ls -lh $CACHE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del aulogpimo_patchcore, pimoresult_patchcore, aucs_patchcore\n",
+    "del aulogpimo_padim, pimoresult_padim, aucs_padim"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load\n",
+    "\n",
+    "Reload back from the disk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anomalib.utils.metrics.perimg import AULogPImO\n",
+    "\n",
+    "pimoresult_padim, aucs_padim = AULogPImO.load(CACHE / \"aulogpimo_padim.json\")\n",
+    "lbound, ubound = aucs_padim[\"lbound\"], aucs_padim[\"ubound\"]  # they are the same for both models\n",
+    "aucs_padim = aucs_padim[\"aulogpimo\"]\n",
+    "\n",
+    "pimoresult_patchcore, aucs_patchcore = AULogPImO.load(CACHE / \"aulogpimo_patchcore.json\")\n",
+    "aucs_patchcore = aucs_patchcore[\"aulogpimo\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "# the funcional interface of the plotting funcions have to be used because the\n",
+    "# aulogpimo object is gone\n",
+    "from anomalib.utils.metrics.perimg.plot import plot_boxplot_logpimo_curves, plot_aulogpimo_boxplot\n",
+    "from anomalib.utils.metrics.perimg.common import perimg_boxplot_stats\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(14, 13))\n",
+    "\n",
+    "for axrow, pimoresult, aucs, model in zip(\n",
+    "    axes, [pimoresult_padim, pimoresult_patchcore], [aucs_padim, aucs_patchcore], [\"PaDiM\", \"PatchCore\"]\n",
+    "):\n",
+    "    _ = plot_aulogpimo_boxplot(aucs, pimoresult.image_classes, axrow[0])\n",
+    "    _ = axrow[0].set_title(f\"{model} - boxplot\")\n",
+    "\n",
+    "    bp_stats = perimg_boxplot_stats(aucs, pimoresult.image_classes, only_class=1)\n",
+    "\n",
+    "    _ = plot_boxplot_logpimo_curves(\n",
+    "        pimoresult.shared_fpr,\n",
+    "        pimoresult.tprs,\n",
+    "        pimoresult.image_classes,\n",
+    "        bp_stats,\n",
+    "        lbound,\n",
+    "        ubound,\n",
+    "        axrow[1],\n",
+    "    )\n",
+    "    _ = axrow[1].set_title(f\"{model} - curves\")\n",
+    "\n",
+    "minmin = min([ax.get_xlim()[0] for ax in axes[:, 0].flatten()])\n",
+    "maxmax = max([ax.get_xlim()[1] for ax in axes[:, 0].flatten()])\n",
+    "for ax in axes[:, 0].flatten():\n",
+    "    _ = ax.set_xlim(minmin, maxmax)\n",
+    "\n",
+    "fig.suptitle(\"AULogPImO: PaDiM vs PatchCore\", fontsize=20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "anomalib-dev-gsoc",
+   "language": "python",
+   "name": "anomalib-dev-gsoc"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/anomalib/utils/metrics/perimg/common.py
+++ b/src/anomalib/utils/metrics/perimg/common.py
@@ -169,7 +169,7 @@ def _validate_and_convert_rate(rate: float | int | Tensor, nonzero: bool = True,
         raise ValueError(f"Expected argument to be a scalar, but got a tensor of shape {rate.shape}.")
 
     if rate < 0 or rate > 1:
-        raise ValueError(f"Argument `rate={rate}` is not a rate.")
+        raise ValueError(f"Argument `{rate}` is not a valid because it is <0 or >1.")
 
     if nonzero and rate == 0:
         raise ValueError("Expected argument to be > 0.")

--- a/src/anomalib/utils/metrics/perimg/pimo.py
+++ b/src/anomalib/utils/metrics/perimg/pimo.py
@@ -305,12 +305,10 @@ class AUPImO(PImO):
             return self.plot_boxplot_pimo_curves(ax=ax)
 
         if not isinstance(ax, ndarray):
-            raise ValueError(f"Expected argument `axes` to be a matplotlib Axes or ndarray, but got {type(ax)}.")
+            raise ValueError(f"Expected argument `ax` to be a matplotlib Axes or ndarray, but got {type(ax)}.")
 
         if ax.size != 2:
-            raise ValueError(
-                f"Expected argument `axes` , when type `ndarray`, to be of size 2, but got size {ax.size}."
-            )
+            raise ValueError(f"Expected argument `ax` , when type `ndarray`, to be of size 2, but got size {ax.size}.")
 
         ax = ax.flatten()
         self.plot_boxplot(ax=ax[0])
@@ -321,31 +319,31 @@ class AUPImO(PImO):
 
     def plot_perimg_fprs(
         self,
-        axes: ndarray | None = None,
+        ax: ndarray | None = None,
     ) -> tuple[Figure | None, ndarray]:
         """Plot the AUC boundary conditions based on FPR metrics on normal images.
 
         Args:
-            axes: ndarray of matplotlib Axes of size 2, or None.
-                If None, the function will create the axes.
+            ax: ndarray of matplotlib Axes of size 2, or None.
+                If None, the function will create the ax.
         Returns:
-            tuple[Figure | None, ndarray]: (fig, axes)
+            tuple[Figure | None, ndarray]: (fig, ax)
                 fig: matplotlib Figure
-                axes: ndarray of matplotlib Axes of size 2
+                ax: ndarray of matplotlib Axes of size 2
         """
 
-        if axes is None:
-            fig, axes = plt.subplots(1, 2, figsize=(14, 6), width_ratios=[6, 8])
+        if ax is None:
+            fig, ax = plt.subplots(1, 2, figsize=(14, 6), width_ratios=[6, 8])
             fig.suptitle("AUPImO Integration Boundary Conditions")
             fig.set_tight_layout(True)
-        elif not isinstance(axes, ndarray):
-            raise ValueError(f"Expected argument `axes` to be an ndarray of matplotlib Axes, but got {type(axes)}.")
-        elif axes.size != 2:
-            raise ValueError(f"Expected argument `axes` to be of size 2, but got size {axes.size}.")
+        elif not isinstance(ax, ndarray):
+            raise ValueError(f"Expected argument `ax` to be an ndarray of matplotlib Axes, but got {type(ax)}.")
+        elif ax.size != 2:
+            raise ValueError(f"Expected argument `ax` to be of size 2, but got size {ax.size}.")
         else:
-            fig, axes = (None, axes)
+            fig, ax = (None, ax)
 
-        axes = axes.flatten()
+        ax = ax.flatten()
 
         (thresholds, fprs, shared_fpr, tprs, image_classes), aucs = self.compute()
 
@@ -354,13 +352,13 @@ class AUPImO(PImO):
         th_lbound = thresholds[thidx_lbound]
 
         plot_th_fpr_curves_norm_only(
-            fprs, shared_fpr, thresholds, image_classes, th_lb_fpr_ub=(th_lbound, self.ubound), ax=axes[0]
+            fprs, shared_fpr, thresholds, image_classes, th_lb_fpr_ub=(th_lbound, self.ubound), ax=ax[0]
         )
 
-        plot_pimfpr_curves_norm_only(fprs, shared_fpr, image_classes, ax=axes[1])
-        _add_integration_range_to_pimo_curves(axes[1], (None, self.ubound))
+        plot_pimfpr_curves_norm_only(fprs, shared_fpr, image_classes, ax=ax[1])
+        _add_integration_range_to_pimo_curves(ax[1], (None, self.ubound))
 
-        return fig, axes
+        return fig, ax
 
 
 class AULogPImO(PImO):
@@ -604,49 +602,47 @@ class AULogPImO(PImO):
             return self.plot_boxplot_logpimo_curves(ax=ax)
 
         if not isinstance(ax, ndarray):
-            raise ValueError(f"Expected argument `axes` to be a matplotlib Axes or ndarray, but got {type(ax)}.")
+            raise ValueError(f"Expected argument `ax` to be a matplotlib Axes or ndarray, but got {type(ax)}.")
 
         if ax.size != 2:
-            raise ValueError(
-                f"Expected argument `axes` , when type `ndarray`, to be of size 2, but got size {ax.size}."
-            )
+            raise ValueError(f"Expected argument `ax` , when type `ndarray`, to be of size 2, but got size {ax.size}.")
 
-        axes = ax.flatten()
-        self.plot_boxplot(ax=axes[0])
-        self.plot_boxplot_logpimo_curves(ax=axes[1])
+        ax = ax.flatten()
+        self.plot_boxplot(ax=ax[0])
+        self.plot_boxplot_logpimo_curves(ax=ax[1])
 
-        if fig is not None:  # it means the axes were created by this function (and so was the suptitle)
-            axes[0].set_title("AUC Boxplot")
-            axes[1].set_title("Curves")
+        if fig is not None:  # it means the ax were created by this function (and so was the suptitle)
+            ax[0].set_title("AUC Boxplot")
+            ax[1].set_title("Curves")
 
-        return fig, axes
+        return fig, ax
 
     def plot_perimg_fprs(
         self,
-        axes: ndarray | None = None,
+        ax: ndarray | None = None,
     ) -> tuple[Figure | None, ndarray]:
         """Plot the AUC boundary conditions based on log(FPR) on normal images.
         Args:
-            axes: ndarray of matplotlib Axes of size 2, or None.
-                If None, the function will create the axes.
+            ax: ndarray of matplotlib Axes of size 2, or None.
+                If None, the function will create the ax.
         Returns:
-            tuple[Figure | None, ndarray]: (fig, axes)
+            tuple[Figure | None, ndarray]: (fig, ax)
                 fig: matplotlib Figure
-                axes: ndarray of matplotlib Axes of size 2
+                ax: ndarray of matplotlib Axes of size 2
         """
 
-        if axes is None:
-            fig, axes = plt.subplots(1, 2, figsize=(14, 6), width_ratios=[6, 8])
+        if ax is None:
+            fig, ax = plt.subplots(1, 2, figsize=(14, 6), width_ratios=[6, 8])
             fig.suptitle("AULogPImO Integration Boundary Conditions")
             fig.set_tight_layout(True)
-        elif not isinstance(axes, ndarray):
-            raise ValueError(f"Expected argument `axes` to be an ndarray of matplotlib Axes, but got {type(axes)}.")
-        elif axes.size != 2:
-            raise ValueError(f"Expected argument `axes` to be of size 2, but got size {axes.size}.")
+        elif not isinstance(ax, ndarray):
+            raise ValueError(f"Expected argument `ax` to be an ndarray of matplotlib Axes, but got {type(ax)}.")
+        elif ax.size != 2:
+            raise ValueError(f"Expected argument `ax` to be of size 2, but got size {ax.size}.")
         else:
-            fig, axes = (None, axes)
+            fig, ax = (None, ax)
 
-        axes = axes.flatten()
+        ax = ax.flatten()
 
         (thresholds, fprs, shared_fpr, _, image_classes), __ = self.compute()
 
@@ -665,10 +661,10 @@ class AULogPImO(PImO):
             image_classes,
             th_lb_fpr_ub=(th_lbound, self.ubound),
             th_ub_fpr_lb=(th_ubound, self.lbound),
-            ax=axes[0],
+            ax=ax[0],
         )
 
-        plot_pimfpr_curves_norm_only(fprs, shared_fpr, image_classes, ax=axes[1])
-        _add_integration_range_to_pimo_curves(axes[1], (self.lbound, self.ubound))
+        plot_pimfpr_curves_norm_only(fprs, shared_fpr, image_classes, ax=ax[1])
+        _add_integration_range_to_pimo_curves(ax[1], (self.lbound, self.ubound))
 
-        return fig, axes
+        return fig, ax

--- a/src/anomalib/utils/metrics/perimg/plot.py
+++ b/src/anomalib/utils/metrics/perimg/plot.py
@@ -304,6 +304,22 @@ def plot_aupimo_boxplot(
     return fig, ax
 
 
+def plot_aulogpimo_boxplot(
+    aucs: Tensor,
+    image_classes: Tensor,
+    random_model_auc: float | None = None,
+    ax: Axes | None = None,
+) -> tuple[Figure | None, Axes]:
+    if random_model_auc is not None:
+        _validate_and_convert_rate(random_model_auc, nonzero=True, nonone=True)
+    fig, ax = plot_aupimo_boxplot(aucs, image_classes, ax=ax)
+    ax.set_xlabel("AULogPImO [%]")
+    ax.set_title("Area Under the Log Per-Image Overlap (AULogPImO) Boxplot")
+    if random_model_auc is not None:
+        _add_avline_at_score_random_model(ax, random_model_auc)
+    return fig, ax
+
+
 # =========================================== PImO ===========================================
 
 

--- a/tests/pre_merge/utils/metrics/test_perimg/test_common.py
+++ b/tests/pre_merge/utils/metrics/test_perimg/test_common.py
@@ -1,13 +1,13 @@
 import torch
 
-from anomalib.utils.metrics.perimg.common import _perimg_boxplot_stats
+from anomalib.utils.metrics.perimg.common import perimg_boxplot_stats
 
 
-def test__perimg_boxplot_stats():
+def test_perimg_boxplot_stats():
     data = torch.arange(100) / 7 - 4  # arbitrary data
     img_cls = (torch.arange(100) % 3 == 0).to(torch.long)
 
-    stats = _perimg_boxplot_stats(data, img_cls)
+    stats = perimg_boxplot_stats(data, img_cls)
     assert len(stats) > 0
     statdic = stats[0]
     assert "statistic" in statdic
@@ -15,8 +15,8 @@ def test__perimg_boxplot_stats():
     assert "nearest" in statdic
     assert "imgidx" in statdic
 
-    _perimg_boxplot_stats(data, img_cls, only_class=0)
+    perimg_boxplot_stats(data, img_cls, only_class=0)
     assert len(stats) > 0
 
-    _perimg_boxplot_stats(data, img_cls, only_class=1)
+    perimg_boxplot_stats(data, img_cls, only_class=1)
     assert len(stats) > 0

--- a/tests/pre_merge/utils/metrics/test_perimg/test_pimo.py
+++ b/tests/pre_merge/utils/metrics/test_perimg/test_pimo.py
@@ -270,10 +270,10 @@ def test_aupimo_plots(anomaly_maps, masks, ubound):
     aupimo.update(anomaly_maps, masks)
     aupimo.compute()
 
-    fig, axes = aupimo.plot()
+    fig, ax = aupimo.plot()
     assert fig is not None
-    assert axes is not None
-    aupimo.plot(axes=axes)
+    assert ax is not None
+    aupimo.plot(ax=ax)
 
     fig, ax = aupimo.plot_all_pimo_curves()
     assert fig is not None
@@ -290,10 +290,10 @@ def test_aupimo_plots(anomaly_maps, masks, ubound):
     assert ax is not None
     aupimo.plot_boxplot_pimo_curves(ax=ax)
 
-    fig, axes = aupimo.plot_perimg_fprs()
+    fig, ax = aupimo.plot_perimg_fprs()
     assert fig is not None
     assert ax is not None
-    aupimo.plot_perimg_fprs(axes=axes)
+    aupimo.plot_perimg_fprs(ax=ax)
 
 
 def test_aulogpimo(
@@ -340,10 +340,10 @@ def test_aulogpimo_plots(anomaly_maps, masks, lbound, ubound):
     aulogpimo.update(anomaly_maps, masks)
     aulogpimo.compute()
 
-    fig, axes = aulogpimo.plot()
+    fig, ax = aulogpimo.plot()
     assert fig is not None
-    assert axes is not None
-    aulogpimo.plot(axes=axes)
+    assert ax is not None
+    aulogpimo.plot(ax=ax)
 
     fig, ax = aulogpimo.plot_all_logpimo_curves()
     assert fig is not None
@@ -360,7 +360,7 @@ def test_aulogpimo_plots(anomaly_maps, masks, lbound, ubound):
     assert ax is not None
     aulogpimo.plot_boxplot_logpimo_curves(ax=ax)
 
-    fig, axes = aulogpimo.plot_perimg_fprs()
+    fig, ax = aulogpimo.plot_perimg_fprs()
     assert fig is not None
     assert ax is not None
-    aulogpimo.plot_perimg_fprs(axes=axes)
+    aulogpimo.plot_perimg_fprs(ax=ax)

--- a/tests/pre_merge/utils/metrics/test_perimg/test_pimo.py
+++ b/tests/pre_merge/utils/metrics/test_perimg/test_pimo.py
@@ -1,3 +1,6 @@
+import tempfile
+from pathlib import Path
+
 import torch
 
 from anomalib.utils.metrics.perimg.pimo import AULogPImO, AUPImO, PImO
@@ -229,6 +232,16 @@ def test_pimo(anomaly_maps, masks):
     assert pimoresult.tprs.ndim == 2
     assert pimoresult.image_classes.ndim == 1
     pimo.plot()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fpath = Path(tmpdir) / "pimo.json"
+        pimo.save(fpath)
+        assert fpath.exists()
+        pimoresult_loaded = pimo.load(tmpdir)
+    assert (pimoresult.thresholds == pimoresult_loaded.thresholds).all()
+    assert (pimoresult.fprs == pimoresult_loaded.fprs).all()
+    assert (pimoresult.shared_fpr == pimoresult_loaded.shared_fpr).all()
+    assert (pimoresult.tprs == pimoresult_loaded.tprs).all()
+    assert (pimoresult.image_classes == pimoresult_loaded.image_classes).all()
 
 
 def test_aupimo(

--- a/tests/pre_merge/utils/metrics/test_perimg/test_pimo.py
+++ b/tests/pre_merge/utils/metrics/test_perimg/test_pimo.py
@@ -351,6 +351,8 @@ def test_aulogpimo(
     lbound,
     ubound,
 ):
+    AULogPImO.random_model_auc_from_bounds(lbound, ubound)
+
     aulogpimo = AULogPImO(num_thresholds=expected_thresholds.shape[0], lbound=lbound, ubound=ubound)
     str(aulogpimo)
     assert 0 < aulogpimo.max_primitive_auc

--- a/tests/pre_merge/utils/metrics/test_perimg/test_plot.py
+++ b/tests/pre_merge/utils/metrics/test_perimg/test_plot.py
@@ -3,12 +3,13 @@
 import matplotlib.pyplot as plt
 import torch
 
-from anomalib.utils.metrics.perimg.common import _perimg_boxplot_stats
+from anomalib.utils.metrics.perimg.common import perimg_boxplot_stats
 from anomalib.utils.metrics.perimg.plot import (
     _plot_perimg_curves,
     _plot_perimg_metric_boxplot,
     plot_all_pimo_curves,
     plot_aupimo_boxplot,
+    plot_boxplot_logpimo_curves,
     plot_boxplot_pimo_curves,
     plot_pimfpr_curves_norm_only,
     plot_pimfpr_curves_norm_vs_anom,
@@ -109,7 +110,7 @@ def test_plot_all_pimo_curves(rates, image_classes):
 
 
 def test__plot_perimg_metric_boxplot(aucs, image_classes, only_class):
-    bp_stats = _perimg_boxplot_stats(aucs, image_classes)
+    bp_stats = perimg_boxplot_stats(aucs, image_classes)
     _, ax = plt.subplots()
     _plot_perimg_metric_boxplot(ax, aucs, image_classes, bp_stats, only_class=only_class)
 
@@ -122,11 +123,19 @@ def test_plot_aupimo_boxplot(aucs, image_classes):
 
 
 def test_plot_boxplot_pimo_curves(aucs, rates, image_classes):
-    bp_stats = _perimg_boxplot_stats(aucs, image_classes)
+    bp_stats = perimg_boxplot_stats(aucs, image_classes)
     fig, ax = plot_boxplot_pimo_curves(rates[0], rates, image_classes, bp_stats)
     assert fig is not None
     assert ax is not None
     plot_boxplot_pimo_curves(rates[0], rates, image_classes, bp_stats, ax=ax)
+
+
+def test_plot_boxplot_logpimo_curves(aucs, rates, image_classes):
+    bp_stats = perimg_boxplot_stats(aucs, image_classes)
+    fig, ax = plot_boxplot_logpimo_curves(rates[0], rates, image_classes, bp_stats, 0.001, 0.03)
+    assert fig is not None
+    assert ax is not None
+    plot_boxplot_logpimo_curves(rates[0], rates, image_classes, bp_stats, 0.001, 0.03, ax=ax)
 
 
 def test_plot_pimfpr_curves_norm_vs_anom(rates, image_classes):

--- a/tests/pre_merge/utils/metrics/test_perimg/test_plot.py
+++ b/tests/pre_merge/utils/metrics/test_perimg/test_plot.py
@@ -8,6 +8,7 @@ from anomalib.utils.metrics.perimg.plot import (
     _plot_perimg_curves,
     _plot_perimg_metric_boxplot,
     plot_all_pimo_curves,
+    plot_aulogpimo_boxplot,
     plot_aupimo_boxplot,
     plot_boxplot_logpimo_curves,
     plot_boxplot_pimo_curves,
@@ -120,6 +121,23 @@ def test_plot_aupimo_boxplot(aucs, image_classes):
     assert fig is not None
     assert ax is not None
     plot_aupimo_boxplot(aucs, image_classes, ax=ax)
+
+
+def test_plot_aulogpimo_boxplot(aucs, image_classes):
+    fig, ax = plot_aulogpimo_boxplot(aucs, image_classes)
+    assert fig is not None
+    assert ax is not None
+    plot_aulogpimo_boxplot(aucs, image_classes, ax=ax)
+
+    fig, ax = plot_aulogpimo_boxplot(
+        aucs,
+        image_classes,
+        # actual value doesn't matter for this test
+        random_model_auc=0.5,
+    )
+    assert fig is not None
+    assert ax is not None
+    plot_aulogpimo_boxplot(aucs, image_classes, ax=ax)
 
 
 def test_plot_boxplot_pimo_curves(aucs, rates, image_classes):


### PR DESCRIPTION
# Description

This is part of [Anomaly Segmentation Metrics for Anomalib — GSoC 2023 @ OpenVINO](https://gist.github.com/jpcbertoldo/12553b7eaa97cfbf3e55bfd7d1cafe88).

## Save & Load

Make it possible to save and load pimo curves and their aucs (`AUPImO` and `AULogPImO`).

`PImO` (parent class of the "AU"s) will save all the returns (fprs, tprs, shared fpr, etc) in a dict of tensors in a `.pt` so the curves are fully recoverable. 

`AUPImO` and `AULogPImO` values (1 per image) are saved in a JSON file so it can be human readable, and they optionally save the curves with an automatic file name based on the JSON file's name.

## Minor refactor

From the previous PR:

> Known issue: the plot functions in AULogPImO were not entirely encapsulated in a function. This was corrected in the next PR.

Adress this and move the logic of the plots from `AULogPImO` to a functional interface (classes practically just pass the arguments).

--- 

# TODO

- [ ] prevent from saving when the metric is empty
- [ ] test above

---

List of refactors before merging feature branch: 
https://github.com/jpcbertoldo/anomalib/blob/metrics/refactors/src/anomalib/utils/metrics/perimg/.refactors

Adds from this PR

```
-
```

---

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
