### PR TITLE
metrics[6]: heatmap visualization with bounds [GSoC23 cont'd]

### DIFF
--- a/src/anomalib/post_processing/post_process.py
+++ b/src/anomalib/post_processing/post_process.py
@@ -183,7 +183,7 @@ def _validate_and_convert_normalize(
         return (anomaly_map.min(), anomaly_map.max())
 
     if ((anomaly_map < 0) | (anomaly_map > 1)).any():
-        raise Exception("When `normalize` is False, anomaly map values are expected to be in [0, 1]")
+        raise ValueError("When `normalize` is False, anomaly map values are expected to be in [0, 1]")
 
     return None
 
@@ -284,7 +284,9 @@ def superimpose_anomaly_map(
     _validate_anomaly_map(anomaly_map)
 
     if anomaly_map.shape != image.shape[:2]:
-        raise Exception()
+        raise ValueError(
+            f"Anomaly map and image must have the same shape, but found {anomaly_map.shape} and {image.shape}"
+        )
 
     # there was a `anomaly_map.squeeze()` before --> do something about it? now it is validated to be squeezed
     color_map = anomaly_map_to_color_map(anomaly_map, normalize=normalize, saturation_colors=saturation_colors)

--- a/src/anomalib/post_processing/post_process.py
+++ b/src/anomalib/post_processing/post_process.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from enum import Enum
 
 import cv2
@@ -82,32 +83,134 @@ def add_anomalous_label(image: np.ndarray, confidence: float | None = None) -> n
     return add_label(image, "anomalous", (255, 100, 100), confidence)
 
 
-def anomaly_map_to_color_map(anomaly_map: np.ndarray, normalize: bool = True) -> np.ndarray:
+def _validate_image(image: np.ndarray) -> None:
+    """TODO move to where? or use another existing one?
+    TODO write excepion messages
+    """
+
+    if not isinstance(image, np.ndarray):
+        raise Exception()
+
+    if image.ndim != 3:
+        raise Exception()
+
+    if image.shape[2] != 3:
+        raise Exception()
+
+    if image.dtype != np.uint8:
+        raise Exception()
+
+
+def _validate_anomaly_map(anomaly_map: np.ndarray) -> None:
+    """TODO move to where? or use another existing one?
+    TODO write excepion messages
+    """
+
+    if not isinstance(anomaly_map, np.ndarray):
+        raise Exception()
+
+    if anomaly_map.ndim != 2:
+        raise Exception()
+
+    # TODO assert it is float type
+
+
+def _validate_normalization_bounds(bounds: tuple[float, float]) -> None:
+    """TODO move to where? or use another existing one?
+    TODO write excepion messages
+    """
+
+    if not isinstance(bounds, Sequence):
+        raise Exception()
+
+    if len(bounds) != 2:
+        raise Exception()
+
+    lower_bound: float
+    upper_bound: float
+    lower_bound, upper_bound = bounds  # type:ignore
+
+    if not isinstance(lower_bound, float) or not isinstance(upper_bound, float):
+        raise Exception()
+
+    if upper_bound <= lower_bound:
+        raise Exception()
+
+
+def _validate_and_convert_normalize(
+    normalize: bool | tuple[float, float], anomaly_map: np.ndarray
+) -> tuple[float, float] | None:
+    """TODO move to where? or use another existing one?
+    TODO write excepion messages    superimposed_map = cv2.addWeighted(color_map, alpha, image, (1 - alpha), gamma)
+
+    """
+
+    if normalize:
+        return (anomaly_map.min(), anomaly_map.max())
+
+    if ((anomaly_map < 0) | (anomaly_map > 1)).any():
+        raise Exception()
+
+    return None
+
+
+def anomaly_map_to_color_map(anomaly_map: np.ndarray, normalize: bool | tuple[float, float] = True) -> np.ndarray:
     """Compute anomaly color heatmap.
+
+    Gets an array of anomaly scores maps and returns a color map according to a normalized scale.
 
     Args:
         anomaly_map (np.ndarray): Final anomaly map computed by the distance metric.
-        normalize (bool, optional): Bool to normalize the anomaly map prior to applying
-            the color map. Defaults to True.
-
+        normalize (bool | tuple[float, float], optional): it can work on three modes:
+            1) (default) bool and True: normalize the anomaly map with its own min/max
+            2) bool and False: values in `anomaly_map` are expected to be \\in [0, 1] (it will be asserted)
+            3) tuple[float, float]: values are expected to be anomaly scores lower and upper bounds; in this case
+                                    these values are used to rescale the scores \in [0, 1] and whatever is
+                                    below/above the lower/upper bound is coloured in black/white.
     Returns:
         np.ndarray: [description]
     """
-    if normalize:
-        anomaly_map = (anomaly_map - anomaly_map.min()) / np.ptp(anomaly_map)
-    anomaly_map = anomaly_map * 255
-    anomaly_map = anomaly_map.astype(np.uint8)
 
-    anomaly_map = cv2.applyColorMap(anomaly_map, cv2.COLORMAP_JET)
-    anomaly_map = cv2.cvtColor(anomaly_map, cv2.COLOR_BGR2RGB)
-    return anomaly_map
+    _validate_anomaly_map(anomaly_map)
+
+    if isinstance(normalize, bool):
+        bounds = _validate_and_convert_normalize(normalize, anomaly_map)
+    else:
+        _validate_normalization_bounds(normalize)
+        bounds = normalize
+
+    if bounds is None:
+        anomaly_map_scaled = anomaly_map
+
+    else:
+        lower_bound, upper_bound = bounds  # normalize the anomaly map
+        anomaly_map_scaled = ((anomaly_map - lower_bound) / (upper_bound - lower_bound)).clip(0, 1)
+
+    color_map = cv2.applyColorMap((anomaly_map_scaled * 255).astype(np.uint8), cv2.COLORMAP_JET)
+    color_map = cv2.cvtColor(color_map, cv2.COLOR_BGR2RGB)  # TODO make colormap an opiton
+
+    if bounds is None:
+        return color_map
+
+    # saturations below and above the score bounds
+    over_mask = anomaly_map > upper_bound
+    under_mask = anomaly_map < lower_bound
+
+    color_map[over_mask, :] = 255  # white # TODO make saturation color an option
+    color_map[under_mask, :] = 0  # black
+
+    return color_map
 
 
 def superimpose_anomaly_map(
-    anomaly_map: np.ndarray, image: np.ndarray, alpha: float = 0.4, gamma: int = 0, normalize: bool = False
+    anomaly_map: np.ndarray,
+    image: np.ndarray,
+    alpha: float = 0.4,
+    gamma: int = 0,
+    normalize: bool | tuple[float, float] = False,
+    ignore_low_scores: bool = True,
 ) -> np.ndarray:
     """Superimpose anomaly map on top of in the input image.
-
     Args:
         anomaly_map (np.ndarray): Anomaly map
         image (np.ndarray): Input image
@@ -117,16 +220,39 @@ def superimpose_anomaly_map(
             to smooth the processing. Defaults to 0. Overall,
             the formula to compute the blended image is
             I' = (alpha*I1 + (1-alpha)*I2) + gamma
-        normalize: whether or not the anomaly maps should
-            be normalized to image min-max
-
+        normalize (bool | tuple[float, float], optional): it can work on three modes:
+            1) (default) bool and True: normalize the anomaly map with its own min/max
+            2) bool and False: values in `anomaly_map` are expected to be \\in [0, 1] (it will be asserted)
+            3) tuple[float, float]: values are expected to be anomaly scores lower and upper bounds; in this case
+                                    these values are used to rescale the scores \in [0, 1] and whatever is
+                                    below/above the lower/upper bound is coloured in black/white.
+        ignore_low_scores (bool, optional): only used when `normalize` is in the case 3 above;
+                                            if true, any score below the lower bound is made transparent
 
     Returns:
         np.ndarray: Image with anomaly map superimposed on top of it.
     """
 
-    anomaly_map = anomaly_map_to_color_map(anomaly_map.squeeze(), normalize=normalize)
-    superimposed_map = cv2.addWeighted(anomaly_map, alpha, image, (1 - alpha), gamma)
+    _validate_image(image)
+    _validate_anomaly_map(anomaly_map)
+
+    if anomaly_map.shape != image.shape[:2]:
+        raise Exception()
+
+    # there was a `anomaly_map.squeeze()` before --> do something about it? now it is validated to be squeezed
+    color_map = anomaly_map_to_color_map(anomaly_map, normalize=normalize)
+    superimposed_map = cv2.addWeighted(color_map, alpha, image, (1 - alpha), gamma)
+
+    if isinstance(normalize, bool) or not ignore_low_scores:
+        return superimposed_map
+
+    # when bounds are given, make anything under the lower bound transparent
+    lower_bound, _ = normalize
+    under_mask = anomaly_map < lower_bound
+
+    # repaint the image over the pixels with score below the lower bound (as if the heatmap was transparent)
+    superimposed_map[under_mask] = image[under_mask]
+
     return superimposed_map
 
 

--- a/src/anomalib/post_processing/post_process.py
+++ b/src/anomalib/post_processing/post_process.py
@@ -84,72 +84,70 @@ def add_anomalous_label(image: np.ndarray, confidence: float | None = None) -> n
 
 
 def _validate_image(image: np.ndarray) -> None:
-    """TODO move to where? or use another existing one?
-    TODO write excepion messages
-    """
+    """TODO move to where? or use another existing one?"""
 
     if not isinstance(image, np.ndarray):
-        raise Exception()
+        raise ValueError(f"Expected a numpy array, but got {type(image).__name__}")
 
     if image.ndim != 3:
-        raise Exception()
+        raise ValueError(f"Expected a 3D array, but got {image.ndim}D array")
 
     if image.shape[2] != 3:
-        raise Exception()
+        raise ValueError(f"Expected a 3-channel image, but got {image.shape[2]} channels")
 
     if image.dtype != np.uint8:
-        raise Exception()
+        raise ValueError(f"Expected a uint8 image, but got {image.dtype} image")
 
 
 def _validate_anomaly_map(anomaly_map: np.ndarray) -> None:
-    """TODO move to where? or use another existing one?
-    TODO write excepion messages
-    """
+    """TODO move to where? or use another existing one?"""
 
     if not isinstance(anomaly_map, np.ndarray):
-        raise Exception()
+        raise ValueError(f"Expected a numpy array, but got {type(anomaly_map).__name__}")
 
     if anomaly_map.ndim != 2:
-        raise Exception()
+        raise ValueError(f"Expected a 2D array, but got {anomaly_map.ndim}D array")
 
-    # TODO assert it is float type
+    if not np.issubdtype(anomaly_map.dtype, np.floating):
+        raise ValueError(f"Expected a floating point array, but got {anomaly_map.dtype} array")
 
 
 def _validate_normalization_bounds(bounds: tuple[float, float]) -> None:
-    """TODO move to where? or use another existing one?
-    TODO write excepion messages
-    """
+    """TODO move to where? or use another existing one?"""
 
     if not isinstance(bounds, Sequence):
-        raise Exception()
+        raise ValueError(f"Expected a sequence, but got {type(bounds).__name__}")
 
     if len(bounds) != 2:
-        raise Exception()
+        raise ValueError(f"Expected a sequence of length 2, but got a sequence of length {len(bounds)}")
 
     lower_bound: float
     upper_bound: float
     lower_bound, upper_bound = bounds  # type:ignore
 
     if not isinstance(lower_bound, float) or not isinstance(upper_bound, float):
-        raise Exception()
+        raise ValueError(
+            "Expected lower/upper bounds to be floats, "
+            f"but got {type(lower_bound).__name__}/{type(upper_bound).__name__}"
+        )
 
     if upper_bound <= lower_bound:
-        raise Exception()
+        raise ValueError(
+            "Expected upper bound to be greater than lower bound, "
+            f"but got (uppper_bound={upper_bound}) <= (lower_bound={lower_bound})"
+        )
 
 
 def _validate_and_convert_normalize(
     normalize: bool | tuple[float, float], anomaly_map: np.ndarray
 ) -> tuple[float, float] | None:
-    """TODO move to where? or use another existing one?
-    TODO write excepion messages    superimposed_map = cv2.addWeighted(color_map, alpha, image, (1 - alpha), gamma)
-
-    """
+    """TODO move to where? or use another existing one?"""
 
     if normalize:
         return (anomaly_map.min(), anomaly_map.max())
 
     if ((anomaly_map < 0) | (anomaly_map > 1)).any():
-        raise Exception()
+        raise Exception("When `normalize` is False, anomaly map values are expected to be in [0, 1]")
 
     return None
 

--- a/src/anomalib/post_processing/post_process.py
+++ b/src/anomalib/post_processing/post_process.py
@@ -83,6 +83,42 @@ def add_anomalous_label(image: np.ndarray, confidence: float | None = None) -> n
     return add_label(image, "anomalous", (255, 100, 100), confidence)
 
 
+def _validate_color(color: tuple[int, int, int]) -> None:
+    """TODO move to where? or use another existing one?"""
+
+    if not isinstance(color, Sequence):
+        raise ValueError(f"Expected a sequence, but got {type(color).__name__}")
+
+    if len(color) != 3:
+        raise ValueError(f"Expected a sequence of length 3, but got a sequence of length {len(color)}")
+
+    channel: int
+    for channelidx, channel in enumerate(color):
+        if not isinstance(channel, int):
+            raise ValueError(f"Expected an integer, but got {type(channel).__name__} on channel {channelidx}")
+
+        if not 0 <= channel <= 255:
+            raise ValueError(f"Expected a value in [0, 255], but got {channel} on channel {channelidx}")
+
+
+def _validate_saturation_colors(saturation_colors: tuple[tuple[int, int, int], tuple[int, int, int]]) -> None:
+    """TODO move to where? or use another existing one?"""
+
+    if not isinstance(saturation_colors, Sequence):
+        raise ValueError(f"Expected a sequence, but got {type(saturation_colors).__name__}")
+
+    if len(saturation_colors) != 2:
+        raise ValueError(f"Expected a sequence of length 2, but got a sequence of length {len(saturation_colors)}")
+
+    color: tuple[int, int, int]
+    for coloridx, color in enumerate(saturation_colors):
+        try:
+            _validate_color(color)
+
+        except ValueError as ex:
+            raise ValueError(f"Got an invalid color on position {coloridx}") from ex
+
+
 def _validate_image(image: np.ndarray) -> None:
     """TODO move to where? or use another existing one?"""
 
@@ -152,7 +188,11 @@ def _validate_and_convert_normalize(
     return None
 
 
-def anomaly_map_to_color_map(anomaly_map: np.ndarray, normalize: bool | tuple[float, float] = True) -> np.ndarray:
+def anomaly_map_to_color_map(
+    anomaly_map: np.ndarray,
+    normalize: bool | tuple[float, float] = True,
+    saturation_colors: tuple[tuple[int, int, int], tuple[int, int, int]] = ((0, 0, 0), (255, 255, 255)),  # black/white
+) -> np.ndarray:
     """Compute anomaly color heatmap.
 
     Gets an array of anomaly scores maps and returns a color map according to a normalized scale.
@@ -165,6 +205,8 @@ def anomaly_map_to_color_map(anomaly_map: np.ndarray, normalize: bool | tuple[fl
             3) tuple[float, float]: values are expected to be anomaly scores lower and upper bounds; in this case
                                     these values are used to rescale the scores \in [0, 1] and whatever is
                                     below/above the lower/upper bound is coloured in black/white.
+        saturation_colors (optional): pair of colors in uint8 RGB format to use to saturate the heatmap below and above
+                                      (default is black/white as described above)
     Returns:
         np.ndarray: [description]
     """
@@ -181,11 +223,15 @@ def anomaly_map_to_color_map(anomaly_map: np.ndarray, normalize: bool | tuple[fl
         anomaly_map_scaled = anomaly_map
 
     else:
+        _validate_saturation_colors(saturation_colors)
+
         lower_bound, upper_bound = bounds  # normalize the anomaly map
         anomaly_map_scaled = ((anomaly_map - lower_bound) / (upper_bound - lower_bound)).clip(0, 1)
 
+        saturation_color_below, saturation_color_above = saturation_colors
+
     color_map = cv2.applyColorMap((anomaly_map_scaled * 255).astype(np.uint8), cv2.COLORMAP_JET)
-    color_map = cv2.cvtColor(color_map, cv2.COLOR_BGR2RGB)  # TODO make colormap an opiton
+    color_map = cv2.cvtColor(color_map, cv2.COLOR_BGR2RGB)
 
     if bounds is None:
         return color_map
@@ -194,8 +240,8 @@ def anomaly_map_to_color_map(anomaly_map: np.ndarray, normalize: bool | tuple[fl
     over_mask = anomaly_map > upper_bound
     under_mask = anomaly_map < lower_bound
 
-    color_map[over_mask, :] = 255  # white # TODO make saturation color an option
-    color_map[under_mask, :] = 0  # black
+    color_map[over_mask, :] = saturation_color_above  # white (default)
+    color_map[under_mask, :] = saturation_color_below  # black (default)
 
     return color_map
 
@@ -206,6 +252,7 @@ def superimpose_anomaly_map(
     alpha: float = 0.4,
     gamma: int = 0,
     normalize: bool | tuple[float, float] = False,
+    saturation_colors: tuple[tuple[int, int, int], tuple[int, int, int]] = ((0, 0, 0), (255, 255, 255)),  # black/white
     ignore_low_scores: bool = True,
 ) -> np.ndarray:
     """Superimpose anomaly map on top of in the input image.
@@ -224,6 +271,8 @@ def superimpose_anomaly_map(
             3) tuple[float, float]: values are expected to be anomaly scores lower and upper bounds; in this case
                                     these values are used to rescale the scores \in [0, 1] and whatever is
                                     below/above the lower/upper bound is coloured in black/white.
+        saturation_colors (optional): pair of colors in uint8 RGB format to use to saturate the heatmap below and above
+                                      (default is black/white as described above)
         ignore_low_scores (bool, optional): only used when `normalize` is in the case 3 above;
                                             if true, any score below the lower bound is made transparent
 
@@ -238,7 +287,7 @@ def superimpose_anomaly_map(
         raise Exception()
 
     # there was a `anomaly_map.squeeze()` before --> do something about it? now it is validated to be squeezed
-    color_map = anomaly_map_to_color_map(anomaly_map, normalize=normalize)
+    color_map = anomaly_map_to_color_map(anomaly_map, normalize=normalize, saturation_colors=saturation_colors)
     superimposed_map = cv2.addWeighted(color_map, alpha, image, (1 - alpha), gamma)
 
     if isinstance(normalize, bool) or not ignore_low_scores:

--- a/src/anomalib/utils/metrics/perimg/common.py
+++ b/src/anomalib/utils/metrics/perimg/common.py
@@ -310,9 +310,9 @@ def perimg_boxplot_stats(
         records.append(
             dict(
                 statistic=stat_,
-                value=val_,
-                nearest=nearest,
-                imgidx=imgidx,
+                value=float(val_),
+                nearest=float(nearest),
+                imgidx=int(imgidx),
             )
         )
 

--- a/tests/pre_merge/post_processing/test_post_process.py
+++ b/tests/pre_merge/post_processing/test_post_process.py
@@ -1,0 +1,93 @@
+import numpy as np
+import pytest
+
+from anomalib.post_processing import anomaly_map_to_color_map, superimpose_anomaly_map
+
+
+def pytest_generate_tests(metafunc):
+    resolution = (256, 256)
+    image = np.zeros(resolution + (3,)).astype(np.uint8)
+    rng = np.random.default_rng()
+    anomaly_map = rng.uniform(0, 1, resolution)
+
+    if "anomaly_map" in metafunc.fixturenames:
+        metafunc.parametrize(
+            argnames=("anomaly_map",),
+            argvalues=[
+                (anomaly_map,),
+            ],
+        )
+
+    if "image" in metafunc.fixturenames:
+        metafunc.parametrize(
+            argnames=("image",),
+            argvalues=[
+                (image,),
+            ],
+        )
+
+
+def test_anomaly_map_to_color_map(anomaly_map):
+    resolution = anomaly_map.shape
+    color_map_shape = resolution + (3,)
+
+    color_map = anomaly_map_to_color_map(anomaly_map)
+    assert color_map.shape == color_map_shape
+
+    # `anomaly_map` must be \in [0, 1] when `normalize=False`
+    anomaly_map[0, 0] = -1
+    with pytest.raises(ValueError):
+        anomaly_map_to_color_map(anomaly_map, normalize=False)
+
+    color_map = anomaly_map_to_color_map(anomaly_map, normalize=True)
+    assert color_map.shape == color_map_shape
+
+    color_map = anomaly_map_to_color_map(anomaly_map, normalize=(0.3, 0.5))
+    assert color_map.shape == color_map_shape
+
+    color_map = anomaly_map_to_color_map(anomaly_map, normalize=(0.3, 0.5), saturation_colors=((0, 0, 0), (1, 1, 1)))
+    assert color_map.shape == color_map_shape
+
+
+def test_superimpose_anomaly_map(anomaly_map, image):
+    resolution = anomaly_map.shape
+    color_map_shape = resolution + (3,)
+
+    sup_img = superimpose_anomaly_map(anomaly_map, image)
+    assert sup_img.shape == color_map_shape
+
+    # `anomaly_map` must be \in [0, 1] when `normalize=False`
+    anomaly_map[0, 0] = -1
+    with pytest.raises(ValueError):
+        superimpose_anomaly_map(anomaly_map, image, normalize=False)
+
+    sup_img = superimpose_anomaly_map(anomaly_map, image, normalize=True)
+    assert sup_img.shape == color_map_shape
+
+    sup_img = superimpose_anomaly_map(anomaly_map, image, normalize=(0.3, 0.5))
+    assert sup_img.shape == color_map_shape
+
+    sup_img = superimpose_anomaly_map(
+        anomaly_map, image, normalize=(0.3, 0.5), saturation_colors=((0, 0, 0), (1, 1, 1))
+    )
+    assert sup_img.shape == color_map_shape
+
+    sup_img = superimpose_anomaly_map(
+        anomaly_map, image, normalize=(0.3, 0.5), saturation_colors=((0, 0, 0), (1, 1, 1)), alpha=0.5, gamma=0.5
+    )
+    assert sup_img.shape == color_map_shape
+
+    sup_img = superimpose_anomaly_map(
+        anomaly_map, image, normalize=(0.3, 0.5), saturation_colors=((0, 0, 0), (1, 1, 1)), ignore_low_scores=True
+    )
+    assert sup_img.shape == color_map_shape
+
+    sup_img = superimpose_anomaly_map(
+        anomaly_map, image, normalize=(0.3, 0.5), saturation_colors=((0, 0, 0), (1, 1, 1)), ignore_low_scores=False
+    )
+    assert sup_img.shape == color_map_shape
+
+    # `ignore_low_scores` should be ignored when `normalize` is boolean
+    sup_img1 = superimpose_anomaly_map(anomaly_map, image, normalize=True, ignore_low_scores=False)
+    sup_img2 = superimpose_anomaly_map(anomaly_map, image, normalize=True, ignore_low_scores=True)
+    assert (sup_img1 == sup_img2).all()


### PR DESCRIPTION
## Description

This is a continuation of [Anomaly Segmentation Metrics for Anomalib — GSoC 2023 @ OpenVINO](https://gist.github.com/jpcbertoldo/12553b7eaa97cfbf3e55bfd7d1cafe88). 

Updated PRs at https://gist.github.com/jpcbertoldo/12553b7eaa97cfbf3e55bfd7d1cafe88?permalink_comment_id=4681988#gistcomment-4681988

---

Replaces https://github.com/jpcbertoldo/anomalib/pull/11

## Changes

This will make it possible to have heat maps with normalization bounds given as an argument, which will used combined with the bounds from `AUPImO`.

It also modifies `superimpose_anomaly_map` to make the anomaly score map transparent wherever the scores are bellow the threshold lower bound (since they'd **never** be classified as `1`).

Example (white means "above upper bound", meaning it is **always** classified as `1`): 

![image](https://github.com/openvinotoolkit/anomalib/assets/24547377/c69a8a5a-4d67-45f2-ab03-668d45c31339)


<details>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which refactors the code base)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [X] I have made corresponding changes to the documentation (If applicable)
- [X] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
